### PR TITLE
Skip response handlers when cookiejar local is not set. 

### DIFF
--- a/lib/response-interceptor-wrapper.js
+++ b/lib/response-interceptor-wrapper.js
@@ -10,7 +10,7 @@ function responseInterceptorResolve (response, instance) {
     const config = response.config;
     const local = config._COOKIEJAR_SUPPORT_LOCAL;
 
-    if (!local.jar || !response.headers['set-cookie']) {
+    if (!local || !local.jar || !response.headers['set-cookie']) {
       return response;
     }
 
@@ -34,6 +34,8 @@ function responseInterceptorResolve (response, instance) {
     const config = response.config;
     const local = config._COOKIEJAR_SUPPORT_LOCAL;
 
+    if (!local) return response;
+
     local.backupOptions.baseURL =
       local.backupOptions.baseURL || config.baseURL;
     local.backupOptions.url =
@@ -51,6 +53,8 @@ function responseInterceptorResolve (response, instance) {
   .then(function redirect (response) {
     const config = response.config;
     const local = config._COOKIEJAR_SUPPORT_LOCAL;
+
+    if (!local) return response;
 
     if (local.redirectCount < 0 || !response.headers['location']) {
       return response;


### PR DESCRIPTION
Fixes issue where introducing a custom adapter breaks the cookiejar instance, e.g.
```

GET /foo/34/edit 200 232.202 ms - -
Trace: TypeError: Cannot read property 'jar' of undefined
    at setCookies (/home/foo/projects/axios-cookiejar-support/lib/response-interceptor-wrapper.js:13:15)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
    at app.router.onReady (/home/foo/projects/myproject/frontend/src/js/server.js:98:25)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

I'm creating an axios cookiejar instance, somewhat like the code below. Everything works fine, until i try to implement a caching strategy, by using a custom adapter. 

```
        this._cache = new Map()
        this.cachingAdapter = async(config) => {
            if (this._cache.has(config.url)) {
                const request = this._cache.get(config.url)
                return this._cache.get(config.url)
            } else {
                const request = await axios.defaults.adapter(config)
                this._cache.set(config.url, request)
                return request
            }
        }


       const axiosCookieJarSupport = require('@3846masa/axios-cookiejar-support')
       let config = {}
       const client = axiosCookieJarSupport(axios).create(config)
       client.get('/some/url/', {adapter: this.cachingAdapter})
```

The suggested fix just checks for local to be defined(it's undefined when used in combination with a custom adapter). Works for me. Please let me know if it needs some more work. I'll be happy to make some additional changes.