### PR TITLE
allow setCookie method options

### DIFF
--- a/lib/interceptors/response.mjs
+++ b/lib/interceptors/response.mjs
@@ -15,11 +15,11 @@ async function responseInterceptor(response, instance) {
     if (Array.isArray(headers['set-cookie'])) {
       const cookies = headers['set-cookie'];
       cookies.forEach(function(cookie) {
-        setCookiePromiseList.push(setCookie(cookie, config.url));
+        setCookiePromiseList.push(setCookie(cookie, config.url, config.setCookieOptions));
       });
     } else {
       const cookie = headers['set-cookie'];
-      setCookiePromiseList.push(setCookie(cookie, config.url));
+      setCookiePromiseList.push(setCookie(cookie, config.url, config.setCookieOptions));
     }
     await Promise.all(setCookiePromiseList);
   }


### PR DESCRIPTION
allow options for tough-cookie setCookie method to be set from the axios config.
https://github.com/salesforce/tough-cookie#setcookiecookieorstring-currenturl-options-cberrcookie