### PR TITLE
ignore cookie errors

### DIFF
--- a/lib/interceptors/response.mjs
+++ b/lib/interceptors/response.mjs
@@ -17,11 +17,11 @@ async function responseInterceptor(response, instance) {
     if (Array.isArray(headers['set-cookie'])) {
       const cookies = headers['set-cookie'];
       cookies.forEach(function(cookie) {
-        setCookiePromiseList.push(setCookie(cookie, config.url));
+        setCookiePromiseList.push(setCookie(cookie, config.url, {ignoreError: true}));
       });
     } else {
       const cookie = headers['set-cookie'];
-      setCookiePromiseList.push(setCookie(cookie, config.url));
+      setCookiePromiseList.push(setCookie(cookie, config.url, {ignoreError: true}));
     }
     await Promise.all(setCookiePromiseList);
   }


### PR DESCRIPTION
Hi Masahiro Miyashiro,

While writing integration tests for a third-party API (outside of my control), I'm seeing an error:

```
Cookie not in this host's domain.
```

(from tough-cookie https://github.com/salesforce/tough-cookie/blob/master/lib/cookie.js#L1030)

In this situation, the API is doing a few 302 redirects and picking up a few cookies, including a cookie with the wrong domain. However, I don't actually care about that particular cookie, but I do want to collect the other cookies into a cookie jar. This error is preventing the rest of the test from working.