### PR TITLE
Fix an issue occuring when headers are undefined in the request.

### DIFF
--- a/lib/interceptors/request.mjs
+++ b/lib/interceptors/request.mjs
@@ -39,8 +39,12 @@ async function requestInterceptor(config, instance) {
       config.baseURL && !isAbsoluteURL(config.url) ? combineURLs(config.baseURL, config.url) : config.url;
     const cookieString = await getCookieString(requestUrl);
     if (cookieString) {
-      const currentCookie = config.headers['Cookie'];
-      config.headers['Cookie'] = [currentCookie, cookieString].filter(c => !!c).join(';\x20');
+      if (config.headers) {
+        const currentCookie = config.headers['Cookie'];
+        config.headers['Cookie'] = [currentCookie, cookieString].filter(c => !!c).join(';\x20');
+      } else {
+        config.headers = { 'Cookie': cookieString };
+      }
     }
   }
 


### PR DESCRIPTION
This pull request fixes an issue with the requestInterceptor() method. Bug occurred when user tries to send a request with either `headers: undefined` or `headers: null` through axios.

## Description
Scenario:
1. Get the global axios instance or instantiate a new one.
1. Call `axiosCookieJarSupport()` on the instance.
1. Instantiates a new `tough.CookieJar()`.
1. Set the cookie as the default jar for axios: `axios.defaults.jar = jar` (not required, same result is observed if the jar is directly in the request config).
1. Set a cookie in the jar.
1. Send a request with undefined headers: `axios.get('url', { headers: null }).then(() => console.log('success');`

### Expected

`success` in the console.

### Actual

```text
    TypeError:_ Cannot read property 'Cookie' of undefined
    at path\node_modules\axios-cookiejar-support\lib\interceptors\request.js:107:45
    at Generator.next (<anonymous>)
    at step (path\node_modules\axios-cookiejar-support\lib\interceptors\response.js:37:19)
    at \node_modules\axios-cookiejar-support\lib\interceptors\response.js:51:13
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:118:7)
```

## Fix

Basically add a check for config headers. If they exists, keeps the same behavior as before, otherwise just set headers on the request with `{ 'Cookie': cookieString }` value.

## Related Issue
No open issue related found.