### PR TITLE
Optionally ignore badly formatted cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ c.f.) https://github.com/mzabriskie/axios#request-config
   // If true, axios create CookieJar automatically.
   jar: undefined, // default
 
+  // After installing cookie support, certain cookie problems
+  // will throw and cause the entire request to fail.
+  // set this true to ignore cookie errors instead
+  ignoreCookieErrors: false // default
+
   // **IMPORTANT**
   // If false, axios DONOT send cookies from cookiejar.
   withCredentials: false // default

--- a/lib/interceptors/response.mjs
+++ b/lib/interceptors/response.mjs
@@ -21,11 +21,11 @@ async function responseInterceptor(response, instance) {
     if (Array.isArray(headers['set-cookie'])) {
       const cookies = headers['set-cookie'];
       cookies.forEach(function(cookie) {
-        setCookiePromiseList.push(setCookie(cookie, config.url));
+        setCookiePromiseList.push(setCookie(cookie, config.url, { ignoreError: config.ignoreCookieErrors }));
       });
     } else {
       const cookie = headers['set-cookie'];
-      setCookiePromiseList.push(setCookie(cookie, config.url));
+      setCookiePromiseList.push(setCookie(cookie, config.url, { ignoreError: config.ignoreCookieErrors }));
     }
     await Promise.all(setCookiePromiseList);
   }

--- a/test.spec.js
+++ b/test.spec.js
@@ -559,6 +559,33 @@ function main(libName) {
           .then(done)
           .catch(done);
       });
+      it('should not ignore bad cookies unless axios config specifies it', (done) => {
+        nock('http://example.com')
+          .get('/')
+          .reply(200, 'OK', { 'Set-Cookie': 'doesn\'t parse' });
+
+        axios
+          .get('http://example.com')
+          .then(() => {
+            throw new Error('did not error on badly formatted cookie');
+          })
+          .catch(e => {
+            assert.notStrictEqual(e.message, 'did not error on badly formatted cookie');
+          })
+          .finally(done);
+      });
+      it('should ignore bad cookies when axios config specifies it', (done) => {
+        nock('http://example.com')
+          .get('/')
+          .reply(200, 'OK', { 'Set-Cookie': 'doesn\'t parse' });
+
+        axios
+          .get('http://example.com', { ignoreCookieErrors: true })
+          .catch(() => {
+            assert.strictEqual(true, false, 'errored on badly formatted cookie after being instructed not to');
+          })
+          .finally(done);
+      });
     });
   });
 }


### PR DESCRIPTION
I am building a crawler and this library is very useful for getting me through some services' need for cookies to be saved (they sometimes go into a redirect loop when cookies are ignored). However, adding it caused another issue: now a poorly formatted cookie will throw the whole request, which is not what I want at all.

tough-cookie's setCookie() function has an ignoreError option, so this pull request simply sets it to match a new axios configuration option that I named `ignoreCookieErrors`.

Automated tests are included.