### PR TITLE
Allow domain to be detected on redirects.

### DIFF
--- a/lib/interceptors/response.mjs
+++ b/lib/interceptors/response.mjs
@@ -18,14 +18,19 @@ async function responseInterceptor(response, instance) {
   if (local.jar && headers['set-cookie']) {
     const setCookie = pify(local.jar.setCookie.bind(local.jar));
     const setCookiePromiseList = [];
+    let { url } = config;
+    if(!url.startsWith('http')) {
+      url = config.baseURL
+    }
+
     if (Array.isArray(headers['set-cookie'])) {
       const cookies = headers['set-cookie'];
       cookies.forEach(function(cookie) {
-        setCookiePromiseList.push(setCookie(cookie, config.url));
+        setCookiePromiseList.push(setCookie(cookie, url));
       });
     } else {
       const cookie = headers['set-cookie'];
-      setCookiePromiseList.push(setCookie(cookie, config.url));
+      setCookiePromiseList.push(setCookie(cookie, url));
     }
     await Promise.all(setCookiePromiseList);
   }


### PR DESCRIPTION
I am not sure as to the corect solution to this issue. I am observing the `config.url` being set to only the path part of the url. So if I am calling `https://example.com/api`, urls is set to '/api'. As a result the cookies are being created with out a domain and then not set on subsequent calls.   

The changes below  worked for my case but I am not sure they will work in all cases. I am happy to implement a more robust solution if there are suggestions. 