### PR TITLE
Added preserveRedirectMethod config flag

### DIFF
--- a/lib/interceptors/response.mjs
+++ b/lib/interceptors/response.mjs
@@ -37,7 +37,7 @@ async function responseInterceptor(response, instance) {
   local.redirectCount--;
 
   if (local.redirectCount >= 0 && isRedirect(statusCode) && !!headers['location']) {
-    if (response.status !== 307) {
+    if (!config.preserveRedirectMethod && response.status !== 307) {
       config.method = 'get';
     }
     config.maxRedirects = local.redirectCount;


### PR DESCRIPTION
Added boolean config flag preserveRedirectMethod to allow original request method to be preserved upon any type of redirect instead of just 307 to be more consistent with axios.

usage: axios('http://localhost:4444/one',{method:'head',preserveRedirectMethod:true})