### PR TITLE
In overwriteRequestFunction this is undefined, use 'instance' instead of this

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -27,7 +27,7 @@ const wrappedDispatchRequest = (config) => {
 
 /** @param {import('axios').AxiosInstance} instance */
 function overwriteRequestFunction(instance) {
-  instance.request = function request(...args) {
+  instance.request = (...args) => {
     const config = {};
     if (typeof args[0] === 'string') {
       Object.assign(config, args[1], { url: args[0] });
@@ -35,17 +35,17 @@ function overwriteRequestFunction(instance) {
       Object.assign(config, args[0]);
     }
 
-    const mergedConfig = mergeConfig(defaultConfig, mergeConfig(this.defaults, config));
-    mergedConfig.jar = config.jar != null ? config.jar : this.defaults.jar;
+    const mergedConfig = mergeConfig(defaultConfig, mergeConfig(instance.defaults, config));
+    mergedConfig.jar = config.jar != null ? config.jar : instance.defaults.jar;
     mergedConfig.method = (mergedConfig.method || 'get').toLowerCase();
     mergedConfig[COOKIEJAR_SUPPORT_LOCAL] = config[COOKIEJAR_SUPPORT_LOCAL];
 
     const chain = [[wrappedDispatchRequest, undefined]];
 
-    this.interceptors.request.forEach((interceptor) => {
+    instance.interceptors.request.forEach((interceptor) => {
       chain.unshift([interceptor.fulfilled, interceptor.rejected]);
     });
-    this.interceptors.response.forEach((interceptor) => {
+    instance.interceptors.response.forEach((interceptor) => {
       chain.push([interceptor.fulfilled, interceptor.rejected]);
     });
 
@@ -56,13 +56,13 @@ function overwriteRequestFunction(instance) {
   };
 
   ['delete', 'get', 'head', 'options'].forEach((method) => {
-    instance[method] = function(url, config = {}) {
-      return this.request(Object.assign(config, { method, url }));
+    instance[method] = (url, config = {}) => {
+      return instance.request(Object.assign(config, { method, url }));
     };
   });
   ['post', 'put', 'patch'].forEach((method) => {
-    instance[method] = function(url, data, config = {}) {
-      return this.request(Object.assign(config, { method, url, data }));
+    instance[method] = (url, data, config = {}) => {
+      return instance.request(Object.assign(config, { method, url, data }));
     };
   });
 }


### PR DESCRIPTION
I encounter the issue while doing a simple request using NestJs Axios HttpService. `this` depends on the context and function `request` does not know what's `this`.