### PR TITLE
fix: change axios semver in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "http-cookie-agent": "^1.0.1"
   },
   "peerDependencies": {
-    "axios": "^0.20.0",
-    "tough-cookie": "^4.0.0"
+    "axios": ">=0.20.0",
+    "tough-cookie": ">=4.0.0"
   },
   "devDependencies": {
     "@ava/typescript": "2.0.0",


### PR DESCRIPTION
* A caret semver less than 1.0.0 pin minor version.
* fixes https://github.com/3846masa/axios-cookiejar-support/issues/410