### PR TITLE
feat: drop Node.js v12 support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ["14", "16", "18"]
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       - uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3.1.1
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       - uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3.1.1
         with:
-          node-version: '14'
+          node-version: "16"
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn build

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,16 @@
 # MIGRATION GUIDES
 
-## Migration guide from v1.0.x to v2.0.0
+## Migration guide from v2.x.x to v3.0.0
 
 - [Update requirements.](#update-requirements)
+
+### Update requirements.
+
+- Node.js v14.18.0 / v16.0.0 or above
+
+## Migration guide from v1.0.x to v2.0.0
+
+- [Update requirements.](#update-requirements-1)
 - [The wrapper function are exported as "named exports".](#the-wrapper-function-are-exported-as-named-exports)
 - [No longer refers to `config.withCredentials`.](#no-longer-refers-to-configwithcredentials)
 - [`config.httpAgent` / `config.httpsAgent` cannot use with `axios-cookiejar-support`.](#confighttpagent--confighttpsagent-cannot-use-with-axios-cookiejar-support)

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "http-cookie-agent": "^1.0.6"
+    "http-cookie-agent": "^2.0.0"
   },
   "peerDependencies": {
     "axios": ">=0.20.0",
@@ -39,7 +39,7 @@
     "@semantic-release/changelog": "5.0.1",
     "@semantic-release/exec": "5.0.0",
     "@semantic-release/git": "9.0.1",
-    "@types/node": "12.20.50",
+    "@types/node": "14.18.16",
     "@types/tough-cookie": "4.0.2",
     "ava": "4.2.0",
     "axios": "0.27.2",
@@ -55,7 +55,7 @@
     "tough-cookie"
   ],
   "engines": {
-    "node": ">=12.19.0 <13.0.0 || >=14.5.0"
+    "node": ">=14.18.0 <15.0.0 || >=16.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,10 +430,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@12.20.50":
-  version "12.20.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.50.tgz#14ba5198f1754ffd0472a2f84ab433b45ee0b65e"
-  integrity sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==
+"@types/node@14.18.16":
+  version "14.18.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.16.tgz#878f670ba3f00482bf859b6550b6010610fc54b5"
+  integrity sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1863,10 +1863,10 @@ http-cache-semantics@^4.1.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
-http-cookie-agent@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/http-cookie-agent/-/http-cookie-agent-1.0.6.tgz#4d11436be06e4b2e00ee2e729a2abd79d969e639"
-  integrity sha512-Ei0BDjMfy6MSXATmCZ5nWr935NLYl6eD/BTxVGOIrKAlg4xDtMdk+8a+caq6Qwa4FACn+vACj89pFKlXmHOnkQ==
+http-cookie-agent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/http-cookie-agent/-/http-cookie-agent-2.0.0.tgz#0b8b7bb6eaecac79a4518421506bc1d7c32709c5"
+  integrity sha512-FHz6qr/U5UB55y+gSJd3qUkqsmMxz/dqjfNZ3DXi8l5atCiD0C+uRwFSbijSibYKFYnSvzp2t1HXx3ZJ5GZ2zA==
   dependencies:
     agent-base "^6.0.2"
 


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js v12 support, please use v14 or above