### PR TITLE
Add custom agent options support to axios-cookiejar-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ const client = wrapper(axios.create({ jar }));
 await client.get('https://example.com');
 ```
 
+## Passing Custom Agent Options
+
+```js
+import axios from 'axios';
+import { wrapper } from 'axios-cookiejar-support';
+import { CookieJar } from 'tough-cookie';
+
+const jar = new CookieJar();
+// Pass custom agent options
+const customAgentOptions = {
+  keepAlive: true,
+  maxSockets: 10,
+  // Add any other options supported by http-cookie-agent
+};
+
+const client = wrapper(axios.create({ jar }), customAgentOptions);
+
+await client.get('https://example.com');
+```
+
 See [examples](./examples) for more details.
 
 ### Extended Request Config

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,56 +10,59 @@ declare module 'axios' {
   }
 }
 
-function requestInterceptor(config: InternalAxiosRequestConfig): InternalAxiosRequestConfig {
-  if (!config.jar) {
+function requestInterceptor(options?: object) {
+  return function (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig {
+    if (!config.jar) {
+      return config;
+    }
+  
+    // @ts-expect-error ...
+    if (config.jar === true) {
+      throw new Error('config.jar does not accept boolean since axios-cookiejar-support@2.0.0.');
+    }
+  
+    if (
+      (config.httpAgent != null && config.httpAgent[AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT] !== true) ||
+      (config.httpsAgent != null && config.httpsAgent[AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT] !== true)
+    ) {
+      throw new Error('axios-cookiejar-support does not support for use with other http(s).Agent.');
+    }
+  
+    config.httpAgent = new HttpCookieAgent({ ...options, cookies: { jar: config.jar }});
+    Object.defineProperty(config.httpAgent, AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT, {
+      configurable: false,
+      enumerable: false,
+      value: true,
+      writable: false,
+    });
+  
+    config.httpsAgent = new HttpsCookieAgent({ ...options, cookies: { jar: config.jar }});
+    Object.defineProperty(config.httpsAgent, AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT, {
+      configurable: false,
+      enumerable: false,
+      value: true,
+      writable: false,
+    });
+  
     return config;
   }
-
-  // @ts-expect-error ...
-  if (config.jar === true) {
-    throw new Error('config.jar does not accept boolean since axios-cookiejar-support@2.0.0.');
-  }
-
-  if (
-    (config.httpAgent != null && config.httpAgent[AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT] !== true) ||
-    (config.httpsAgent != null && config.httpsAgent[AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT] !== true)
-  ) {
-    throw new Error('axios-cookiejar-support does not support for use with other http(s).Agent.');
-  }
-
-  config.httpAgent = new HttpCookieAgent({ cookies: { jar: config.jar } });
-  Object.defineProperty(config.httpAgent, AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT, {
-    configurable: false,
-    enumerable: false,
-    value: true,
-    writable: false,
-  });
-
-  config.httpsAgent = new HttpsCookieAgent({ cookies: { jar: config.jar } });
-  Object.defineProperty(config.httpsAgent, AGENT_CREATED_BY_AXIOS_COOKIEJAR_SUPPORT, {
-    configurable: false,
-    enumerable: false,
-    value: true,
-    writable: false,
-  });
-
-  return config;
 }
 
-export function wrapper<T extends AxiosStatic | AxiosInstance>(axios: T): T {
-  const isWrapped = axios.interceptors.request.handlers.find(({ fulfilled }) => fulfilled === requestInterceptor);
+export function wrapper<T extends AxiosStatic | AxiosInstance>(axios: T, opts?: object): T {
+  const interceptor = requestInterceptor(opts);
+  const isWrapped = axios.interceptors.request.handlers.find(({ fulfilled }) => fulfilled === interceptor);
 
   if (isWrapped) {
     return axios;
   }
 
-  axios.interceptors.request.use(requestInterceptor);
+  axios.interceptors.request.use(interceptor);
 
   if ('create' in axios) {
     const create = axios.create;
     axios.create = (...args) => {
       const instance = create.apply(axios, args);
-      instance.interceptors.request.use(requestInterceptor);
+      instance.interceptors.request.use(interceptor);
       return instance;
     };
   }


### PR DESCRIPTION
I needed a way to customize the httpsAgent.

My use case was to set rejectUnauthorized: false.