### PR TITLE
fix: restore main / types fields for npm ts badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
       }
     }
   },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
     "noop.js"


### PR DESCRIPTION
* fixed https://github.com/3846masa/axios-cookiejar-support/issues/1347