### PR TITLE
Improve module resolution compatibility with bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
       "browser": {
         "default": "./noop.js",
         "types": "./dist/index.d.ts"
+      },
+      "default": {
+        "default": "./dist/index.js",
+        "types": "./dist/index.d.ts"
       }
     }
   },


### PR DESCRIPTION
## Problem
When using this package with TypeScript projects that have `"moduleResolution": "bundler"` in their tsconfig.json, module resolution fails because bundlers cannot properly resolve the nested `default` conditions in the exports field.

## Changes
Modified the `exports` field in package.json to include a top-level `default` condition while maintaining the existing nested structure for backward compatibility.

## Testing
Verified that the package can be properly imported in projects with:
- TypeScript with `"moduleResolution": "bundler"`
- Node.js environments
- Browser environments

This change is non-breaking and improves compatibility with modern tooling.