### PR TITLE
Fix export key order

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
   "exports": {
     ".": {
       "node": {
-        "default": "./dist/index.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       },
       "browser": {
-        "default": "./noop.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./noop.js"
       },
       "default": {
-        "default": "./dist/index.js",
-        "types": "./dist/index.d.ts"
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   },


### PR DESCRIPTION
I imported `axios-cookiejar-support` in my NextJS 14 app and I started getting `Module not found: Default condition should be last one`.

Upon reading a little about this error, I found that the order of the `default` key in `package.json`'s `export` object [is supposed to be the last key](https://nodejs.org/api/packages.html#exports:~:text=%22default%22%20%2D%20the%20generic%20fallback%20that%20always%20matches.%20Can%20be%20a%20CommonJS%20or%20ES%20module%20file.%20This%20condition%20should%20always%20come%20last.), but it's not.

